### PR TITLE
Migrate publishing to Central Portal (vanniktech + auto-release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,8 @@ name: Deployment
 on:
   push:
     branches:
-      - master
+      - develop  # publishes an overwritable -SNAPSHOT
+      - master   # auto-releases the permanent version to Maven Central
 
 jobs:
   deploy:
@@ -15,12 +16,12 @@ jobs:
         uses: Oztechan/Global/actions/setup-gradle-repo@8610938e630b3ed86127765237fe3647b9fabd4f
 
       - name: Publish
-        run: ./gradlew publish
+        run: ./gradlew publishToMavenCentral --no-configuration-cache
         env:
-          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
-          GPG_KEY: ${{ secrets.GPG_KEY }}
-          GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSWORD }}
 
       - name: Notify slack success
         if: success()

--- a/BaseMob.gradle.kts
+++ b/BaseMob.gradle.kts
@@ -6,11 +6,16 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     libs.plugins.apply {
         alias(androidLibrary).apply(false)
+        alias(mavenPublish).apply(false)
     }
 }
 
 allprojects {
     project.dependencyLocking.lockAllConfigurations()
+
+    // Group + POM metadata + Central Portal config come from gradle.properties (read by
+    // com.vanniktech.maven.publish). Only the version is dynamic (git commit count).
+    version = ProjectSettings.getVersionName(project)
 
     repositories {
         google()

--- a/basemob/basemob.gradle.kts
+++ b/basemob/basemob.gradle.kts
@@ -1,7 +1,6 @@
 /*
  * Copyright (c) 2020 Mustafa Ozhan. All rights reserved.
  */
-@file:Suppress("DEPRECATION") // vanniktech AndroidSingleVariantLibrary(Boolean, Boolean) ctor — still valid
 
 import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
 
@@ -41,6 +40,7 @@ mavenPublishing {
     // Coordinates (GROUP + POM_ARTIFACT_ID), POM, host and auto-release come from gradle.properties.
     // Publishes the release AAR + sources + javadoc. Central Portal requires signed artifacts;
     // keys are provided in CI via ORG_GRADLE_PROJECT_* env.
+    @Suppress("DEPRECATION")
     configure(AndroidSingleVariantLibrary(variant = "release", sourcesJar = true, publishJavadocJar = true))
     signAllPublications()
 }

--- a/basemob/basemob.gradle.kts
+++ b/basemob/basemob.gradle.kts
@@ -1,14 +1,14 @@
 /*
  * Copyright (c) 2020 Mustafa Ozhan. All rights reserved.
  */
-import java.io.IOException
-import java.util.Properties
+@file:Suppress("DEPRECATION") // vanniktech AndroidSingleVariantLibrary(Boolean, Boolean) ctor — still valid
+
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
 
 plugins {
     libs.plugins.apply {
         alias(androidLibrary)
-        `maven-publish`
-        signing
+        alias(mavenPublish)
     }
 }
 
@@ -37,117 +37,10 @@ dependencies {
     }
 }
 
-tasks {
-    register("androidJavadocJar", Jar::class) {
-        archiveClassifier.set("javadoc")
-        from("${layout.buildDirectory}/javadoc")
-    }
-
-    register("androidSourcesJar", Jar::class) {
-        archiveClassifier.set("sources")
-        from("src/main/kotlin", "src/main/java")
-    }
-}
-
-publishing {
-    publications {
-        register<MavenPublication>("mavenAndroid") {
-            Library.apply {
-                group = GROUP
-                version = ProjectSettings.getVersionName(project)
-
-                afterEvaluate {
-                    artifact(tasks.getByName("bundleReleaseAar"))
-
-                    extensions.findByType<PublishingExtension>()?.apply {
-                        repositories {
-                            maven {
-                                url = uri(if (isReleaseBuild) RELEASE_URL else SNAPSHOT_URL)
-                                credentials {
-                                    username = getSecret("MAVEN_USERNAME")
-                                    password = getSecret("MAVEN_PASSWORD")
-                                }
-                            }
-                        }
-                    }
-
-                    extensions.findByType<PublishingExtension>()?.let { publishing ->
-                        val key = getSecret("GPG_KEY").replace("\\n", "\n")
-                        val password = getSecret("GPG_PASSWORD")
-
-                        extensions.findByType<SigningExtension>()?.apply {
-                            useInMemoryPgpKeys(key, password)
-                            sign(publishing.publications)
-                        }
-                    }
-
-                    tasks.withType<Sign>().configureEach {
-                        onlyIf { isReleaseBuild }
-                    }
-                }
-
-                artifact(tasks.getByName("androidJavadocJar"))
-                artifact(tasks.getByName("androidSourcesJar"))
-
-                pom {
-
-                    name.set(NAME)
-                    description.set(DESCRIPTION)
-                    url.set(URL)
-
-                    licenses {
-                        license {
-                            name.set(LICENSE_NAME)
-                            url.set(LICENSE_URL)
-                            distribution.set(LICENSE_DISTRIBUTION)
-                        }
-                    }
-                    developers {
-                        developer {
-                            id.set(DEVELOPER_ID)
-                            name.set(DEVELOPER_NAME)
-                            email.set(DEVELOPER_EMAIL)
-                        }
-                    }
-                    scm { url.set(URL) }
-                }
-            }
-        }
-    }
-}
-
-val isReleaseBuild: Boolean
-    get() = System.getenv("GPG_KEY") != null
-
-fun getSecret(
-    key: String,
-    default: String = "secret" // these values can not be public
-): String = System.getenv(key).let {
-    if (it.isNullOrEmpty()) {
-        getSecretProperties()?.get(key)?.toString() ?: default
-    } else {
-        it
-    }
-}
-
-fun getSecretProperties() = try {
-    Properties().apply { load(file("$projectDir/key.properties").inputStream()) }
-} catch (e: IOException) {
-    logger.debug(e.message, e)
-    null
-}
-
-object Library {
-    const val GROUP = "com.github.submob"
-    const val URL = "https://github.com/SubMob/BaseMob"
-    const val NAME = "BaseMob"
-    const val DESCRIPTION = "Set of base classes for Android"
-    const val DEVELOPER_NAME = "Mustafa Ozhan"
-    const val DEVELOPER_ID = "mustafaozhan"
-    const val DEVELOPER_EMAIL = "mr.mustafa.ozhan@gmail.com"
-    const val LICENSE_NAME = "The Apache Software License, Version 2.0"
-    const val LICENSE_URL = "http://www.apache.org/licenses/LICENSE-2.0.txt"
-    const val LICENSE_DISTRIBUTION = "repo"
-    const val RELEASE_URL = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2"
-    const val SNAPSHOT_URL = "https://s01.oss.sonatype.org/content/repositories/snapshots"
+mavenPublishing {
+    // Coordinates (GROUP + POM_ARTIFACT_ID), POM, host and auto-release come from gradle.properties.
+    // Publishes the release AAR + sources + javadoc. Central Portal requires signed artifacts;
+    // keys are provided in CI via ORG_GRADLE_PROJECT_* env.
+    configure(AndroidSingleVariantLibrary(variant = "release", sourcesJar = true, publishJavadocJar = true))
+    signAllPublications()
 }

--- a/buildSrc/src/main/kotlin/ProjectSettings.kt
+++ b/buildSrc/src/main/kotlin/ProjectSettings.kt
@@ -16,9 +16,24 @@ object ProjectSettings {
 
     val JAVA_VERSION = JavaVersion.VERSION_21
 
-    fun getVersionName(
-        project: Project
-    ) = "$MAYOR_VERSION.$MINOR_VERSION.${gitCommitCount(project).toInt() - VERSION_DIF}"
+    fun getVersionName(project: Project): String = if (isMaster(project)) {
+        // Permanent, pinnable release: x.y.<commit-count>.
+        "$MAYOR_VERSION.$MINOR_VERSION.${gitCommitCount(project).toInt() - VERSION_DIF}"
+    } else {
+        // Stable moving snapshot ("latest develop") — consumers pin x.y-SNAPSHOT and always get newest.
+        "$MAYOR_VERSION.$MINOR_VERSION-SNAPSHOT"
+    }
+
+    private fun isMaster(project: Project): Boolean = currentBranch(project) == "master"
+
+    private fun currentBranch(project: Project): String {
+        // In GitHub Actions the checked-out branch is exposed as GITHUB_REF_NAME; fall back to git locally.
+        val ciBranch = project.providers.environmentVariable("GITHUB_REF_NAME").orNull
+        if (!ciBranch.isNullOrBlank()) return ciBranch
+        return project.providers.exec {
+            commandLine("git rev-parse --abbrev-ref HEAD".split(" "))
+        }.standardOutput.asText.get().trim()
+    }
 
     private fun gitCommitCount(project: Project): String = project.providers.exec {
         commandLine("git rev-list --first-parent --count HEAD".split(" "))

--- a/buildSrc/src/main/kotlin/ProjectSettings.kt
+++ b/buildSrc/src/main/kotlin/ProjectSettings.kt
@@ -8,11 +8,11 @@ object ProjectSettings {
     const val COMPILE_SDK_VERSION = 36
     const val MIN_SDK_VERSION = 3
 
-    private const val MAYOR_VERSION = 2
-    private const val MINOR_VERSION = 1
+    private const val MAYOR_VERSION = 3
+    private const val MINOR_VERSION = 0
 
-    // git rev-list --first-parent --count master +1
-    private const val VERSION_DIF = 156
+    // git rev-list --first-parent --count master (recalibrated at the 3.0 major bump)
+    private const val VERSION_DIF = 162
 
     val JAVA_VERSION = JavaVersion.VERSION_21
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,22 @@ org.gradle.configuration-cache=true
 kotlin.code.style=official
 kotlin.build.report.output=build_scan,file
 kotlin.incremental=true
+# Maven Central publishing (Central Portal) via com.vanniktech.maven.publish
+GROUP=com.github.submob
+POM_ARTIFACT_ID=basemob
+POM_NAME=BaseMob
+POM_DESCRIPTION=Set of base classes for Android
+POM_INCEPTION_YEAR=2020
+POM_URL=https://github.com/SubMob/BaseMob
+POM_LICENSE_NAME=The Apache Software License, Version 2.0
+POM_LICENSE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
+POM_LICENSE_DIST=repo
+POM_DEVELOPER_ID=mustafaozhan
+POM_DEVELOPER_NAME=Mustafa Ozhan
+POM_DEVELOPER_EMAIL=mr.mustafa.ozhan@gmail.com
+POM_SCM_URL=https://github.com/SubMob/BaseMob
+POM_SCM_CONNECTION=scm:git:git://github.com/SubMob/BaseMob.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/SubMob/BaseMob.git
+# Publish to the new Central Portal and auto-release (no manual "release" step)
+SONATYPE_HOST=CENTRAL_PORTAL
+SONATYPE_AUTOMATIC_RELEASE=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@
 androidGradlePlugin = "9.2.1"
 androidMaterial = "1.14.0"
 navigation = "2.9.8"
+mavenPublish = "0.37.0"
 
 [libraries]
 # ANDROID
@@ -12,3 +13,4 @@ android-navigation = { module = "androidx.navigation:navigation-fragment-ktx", v
 [plugins]
 
 androidLibrary = { id = "com.android.library", version.ref = "androidGradlePlugin" }
+mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }


### PR DESCRIPTION
The retired OSSRH endpoint (`s01.oss.sonatype.org`, shut down June 2025) is replaced with the Sonatype Central Portal via the `com.vanniktech.maven.publish` plugin, with automatic release.

- `develop` → publishes a stable `X.Y-SNAPSHOT` (a moving "latest dev" that consumers can pin)
- `master` → auto-releases the permanent `X.Y.<commit-count>` to Maven Central (no manual release step)

Credentials + signing move to `ORG_GRADLE_PROJECT_*` env, and the hand-rolled `maven-publish`/signing configuration is removed.


Resolves SubMob/BaseMob#277
